### PR TITLE
Added --depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Usage:
 Application Options:
   -w, --working-dir= set the working directory (default: .)
       --no-group     do not group same outputs
+  -d, --depth=       depth of folders to look into for git repositories
+                     (default: 1)
 
 Help Options:
   -h, --help         Show this help message

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 var opts struct {
 	WorkingDir string `short:"w" long:"working-dir" default:"." description:"set the working directory"`
 	NoGroup    bool   `long:"no-group" description:"do not group same outputs"`
+	Depth      int    `short:"d" long:"depth" default:"1" description:"depth of folders to look into for git repositories"`
 }
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 
 	opts.WorkingDir = path.Clean(opts.WorkingDir)
 
-	repos, err := Repos(opts.WorkingDir)
+	repos, err := Repos(opts.WorkingDir, 1, opts.Depth)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get git repos: %v\n", err)
 		os.Exit(1)

--- a/outputs.go
+++ b/outputs.go
@@ -25,7 +25,7 @@ func outputs(repos []Repo, results chan result, group bool) ([]output, error) {
 		if group {
 			key = result.out
 		} else {
-			key = result.repo.Name()
+			key = result.repo.Path
 		}
 
 		seen[key] = append(seen[key], result)
@@ -38,7 +38,7 @@ func outputs(repos []Repo, results chan result, group bool) ([]output, error) {
 	for _, results := range seen {
 		repos := make([]string, len(results))
 		for i, result := range results {
-			repos[i] = result.repo.Name()
+			repos[i] = result.repo.Path
 		}
 
 		outputs = append(outputs, output{repos, results[0].out})


### PR DESCRIPTION
Added an option to pass which depth should be looked into
when looking for git repos. All values less than `1` are
considered as `1`.

Closes #4